### PR TITLE
memory leak fix

### DIFF
--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/animatedDrawables/CircularAnimatedDrawable.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/animatedDrawables/CircularAnimatedDrawable.java
@@ -209,4 +209,21 @@ public class CircularAnimatedDrawable extends Drawable implements Animatable {
     }
 
 
+    public void dispose()
+    {
+        if (mValueAnimatorAngle != null)
+        {
+            mValueAnimatorAngle.end();
+            mValueAnimatorAngle.removeAllUpdateListeners();
+            mValueAnimatorAngle.cancel();
+        }
+        mValueAnimatorAngle = null;
+        if (mValueAnimatorSweep != null)
+        {
+            mValueAnimatorSweep.end();
+            mValueAnimatorSweep.removeAllUpdateListeners();
+            mValueAnimatorSweep.cancel();
+        }
+        mValueAnimatorSweep = null;
+    }
 }

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/animatedDrawables/CircularRevealAnimatedDrawable.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/animatedDrawables/CircularRevealAnimatedDrawable.java
@@ -186,4 +186,15 @@ public class CircularRevealAnimatedDrawable extends Drawable implements Animatab
     public int getOpacity() {
         return 0;
     }
+
+    public void dispose()
+    {
+        if (mRevealInAnimation != null)
+        {
+            mRevealInAnimation.end();
+            mRevealInAnimation.removeAllUpdateListeners();
+            mRevealInAnimation.cancel();
+        }
+        mRevealInAnimation = null;
+    }
 }

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
@@ -19,11 +19,11 @@ import android.util.AttributeSet;
 import android.view.ViewGroup;
 import android.widget.Button;
 
+import br.com.simplepass.loading_button_lib.R;
 import br.com.simplepass.loading_button_lib.Utils;
 import br.com.simplepass.loading_button_lib.UtilsJava;
 import br.com.simplepass.loading_button_lib.animatedDrawables.CircularAnimatedDrawable;
 import br.com.simplepass.loading_button_lib.animatedDrawables.CircularRevealAnimatedDrawable;
-import br.com.simplepass.loading_button_lib.R;
 import br.com.simplepass.loading_button_lib.interfaces.AnimatedButton;
 import br.com.simplepass.loading_button_lib.interfaces.OnAnimationEndListener;
 
@@ -409,6 +409,15 @@ public class CircularProgressButton extends Button implements AnimatedButton {
 
         mIsMorphingInProgress = true;
         mAnimatorSet.start();
+    }
+
+    @Override
+    public void dispose()
+    {
+        if (mAnimatedDrawable != null)
+            mAnimatedDrawable.dispose();
+        if (mRevealDrawable != null)
+            mRevealDrawable.dispose();
     }
 
     /**

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
@@ -20,11 +19,11 @@ import android.util.AttributeSet;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 
+import br.com.simplepass.loading_button_lib.R;
 import br.com.simplepass.loading_button_lib.Utils;
 import br.com.simplepass.loading_button_lib.UtilsJava;
 import br.com.simplepass.loading_button_lib.animatedDrawables.CircularAnimatedDrawable;
 import br.com.simplepass.loading_button_lib.animatedDrawables.CircularRevealAnimatedDrawable;
-import br.com.simplepass.loading_button_lib.R;
 import br.com.simplepass.loading_button_lib.interfaces.AnimatedButton;
 import br.com.simplepass.loading_button_lib.interfaces.OnAnimationEndListener;
 
@@ -413,6 +412,18 @@ public class CircularProgressImageButton extends ImageButton implements Animated
 
         mIsMorphingInProgress = true;
         mMorphingAnimatorSet.start();
+    }
+
+    @Override
+    public void dispose()
+    {
+        if (mMorphingAnimatorSet != null)
+        {
+            mMorphingAnimatorSet.end();
+            mMorphingAnimatorSet.removeAllListeners();
+            mMorphingAnimatorSet.cancel();
+        }
+        mMorphingAnimatorSet = null;
     }
 
     /**

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/interfaces/AnimatedButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/interfaces/AnimatedButton.java
@@ -8,4 +8,5 @@ public interface AnimatedButton {
     void startAnimation();
     void revertAnimation();
     void revertAnimation(final OnAnimationEndListener onAnimationEndListener);
+    void dispose();
 }


### PR DESCRIPTION
Fix memory leak as described in #4 

If `revertAnimation()` is called from an alternate thread some of the `AnimatorSet`s will leak and need to be disposed. In this implementation, the user has to call `.dispose()` on their `CircularProgressButton`s

I've previously seen a similar situation on the Facebook shimmer library and adapted [a user's solution](https://github.com/facebook/shimmer-android/issues/14#issuecomment-233785165) to this.