### PR TITLE
Hide compound drawables on animation start

### DIFF
--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
@@ -448,6 +448,7 @@ public class CircularProgressButton extends Button implements AnimatedButton {
 
         mState = State.PROGRESS;
 
+        this.setCompoundDrawables(null, null, null, null); 
         this.setText(null);
         setClickable(false);
 


### PR DESCRIPTION
I found that compound drawables (drawableStart/drawableEnd) would be kept when starting the animation. These should in most cases be hidden, just like the button text is hidden on animation start. 