### PR TITLE
Simplified the programmatic text setting for the CircularProgressButton.

### DIFF
--- a/app/src/main/java/br/com/simplepass/loadingbutton/AnkoActivity.kt
+++ b/app/src/main/java/br/com/simplepass/loadingbutton/AnkoActivity.kt
@@ -32,7 +32,6 @@ class AnkoActivity : AppCompatActivity() {
                 setFinalCornerRadius(0F)
                 setFinalCornerRadius(1000F)
                 text = "Some text"
-                setButtonText("Some text")
             }
         }
     }

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
@@ -34,7 +34,7 @@ import br.com.simplepass.loading_button_lib.interfaces.OnAnimationEndListener;
  * Made by Leandro Ferreira.
  *
  */
-public class CircularProgressButton extends AppCompatButton implements AnimatedButton, CustomizableByCodeWithText {
+public class CircularProgressButton extends AppCompatButton implements AnimatedButton, CustomizableByCode {
     private enum State {
         PROGRESS, IDLE, DONE, STOPED
     }
@@ -215,11 +215,6 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
     @Override
     public void setFinalCornerRadius(float radius) {
         mParams.mFinalCornerRadius = radius;
-    }
-
-    @Override
-    public void setButtonText(String text) {
-        mParams.mText = text;
     }
 
     /**
@@ -440,6 +435,8 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         }
 
         mState = State.PROGRESS;
+
+        mParams.mText = getText().toString();
 
         this.setCompoundDrawables(null, null, null, null);
         this.setText(null);

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CustomizableByCodeWithText.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CustomizableByCodeWithText.java
@@ -1,5 +1,0 @@
-package br.com.simplepass.loading_button_lib.customViews;
-
-public interface CustomizableByCodeWithText extends CustomizableByCode {
-    void setButtonText(String text);
-}


### PR DESCRIPTION
I think the way you are currently doing the programmatic setting of the text is a bit confusing, since you're essentially adding a method that needs to be called at the same time as `setText` when instantiating a `CircularProgressButton` programmatically (you can actually see this in your `AnkoActivity`). 
So instead I propose to remove the custom text setting code and just calling the normal Android `setText`, and when the animation starts you simply store the current button's text in the `mParams`. Let me know what you think. 