### PR TITLE
Manifest Cleanup 

### DIFF
--- a/loading-button-android/src/main/AndroidManifest.xml
+++ b/loading-button-android/src/main/AndroidManifest.xml
@@ -1,9 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="br.com.simplepass.loading_button_lib">
-
-    <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-    </application>
-
-</manifest>
+<manifest package="br.com.simplepass.loading_button_lib"/>

--- a/loading-button-android/src/main/res/values/strings.xml
+++ b/loading-button-android/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Loading Button</string>
-</resources>


### PR DESCRIPTION
While I'm at it, I've also cleaned up the library manifest a bit: 
* Removed the `supportsRtl` property as this should not be defined within a library, it is up to an app to determine whether it supports Rtl or not. This causes problems when you include your library within an app that does not support Rtl. There is a way to remove this on the app side by using `tools:replace` but it's much cleaner/easier to remove it from the library since it doesn't matter in any case. 
* Removed the application name from the library, because it will never be used in any case
* Removed the Strings file, since you don't need the application name anymore. 
* Removed the application declaration and the Android namespace from the manifest, since they are useless without anything defined within them. 

Let me know if you have any thoughts!
