### PR TITLE
Supporting InsetDrawables and StateListDrawables with different states

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You can check how this library was implemented here: https://medium.com/p/9efee6
  - [Configure XML](#configure-xml)
  - [Avoid Memory Leaks](#avoid-memory-leaks)
  - [Be Creative](#be-creative)
- - [Wanna Contribute?](#wanna-contribute)
  - [Bugs and feedback](#bugs-and-feedback)
  - [Credits](#credits)
 
@@ -57,6 +56,15 @@ Then, instanciate the button
 		btn.doneLoadingAnimation(fillColor, bitmap); 
 		[or just revert de animation]
 		btn.revertAnimation();
+
+### Switch to determinant progress
+You can switch between indeterminant and determinant progress:
+
+    circularProgressButton.setProgress(10)
+    ...
+    circularProgressButton.setProgress(100)
+    ...
+    circularProgressButton.resetProgress()
 
 ### - Show 'done' animation
 

--- a/app/src/main/java/br/com/simplepass/loadingbutton/MainActivity.kt
+++ b/app/src/main/java/br/com/simplepass/loadingbutton/MainActivity.kt
@@ -30,19 +30,19 @@ class MainActivity : AppCompatActivity() {
         progressButtonNoPadding.setOnClickListener { _ ->
             animateButtonAndRevert(progressButtonNoPadding,
                     ContextCompat.getColor(this@MainActivity, R.color.black),
-                    BitmapFactory.decodeResource(resources, R.drawable.ic_alarm_on_white_48dp))
+                    BitmapFactory.decodeResource(resources, R.drawable.ic_alarm_on_white_48dp), false)
         }
 
         progressButton2.setOnClickListener { _ ->
             animateButtonAndRevert(progressButton2,
                     ContextCompat.getColor(this@MainActivity, R.color.transparent),
-                    BitmapFactory.decodeResource(resources, R.drawable.ic_cloud_upload_white_24dp))
+                    BitmapFactory.decodeResource(resources, R.drawable.ic_cloud_upload_white_24dp), false)
         }
 
         progressButtonNoPadding2.setOnClickListener { _ ->
             animateButtonAndRevert(progressButtonNoPadding2,
                     ContextCompat.getColor(this@MainActivity, R.color.colorAccent),
-                    BitmapFactory.decodeResource(resources, R.drawable.ic_pregnant_woman_white_48dp))
+                    BitmapFactory.decodeResource(resources, R.drawable.ic_pregnant_woman_white_48dp), true)
         }
 
         progressButtonChangeActivity.setOnClickListener { view ->
@@ -69,7 +69,8 @@ class MainActivity : AppCompatActivity() {
 
     }
 
-    private fun animateButtonAndRevert(circularProgressButton: CircularProgressButton, fillColor: Int, bitmap: Bitmap) {
+    private fun animateButtonAndRevert(circularProgressButton: CircularProgressButton, fillColor: Int, bitmap:
+    Bitmap, determinateProgress: Boolean) {
         val handler = Handler()
 
         val runnable = {
@@ -87,6 +88,15 @@ class MainActivity : AppCompatActivity() {
         circularProgressButton.revertAnimation()
 
         circularProgressButton.startAnimation()
+
+        if (determinateProgress) {
+            handler.postDelayed({ circularProgressButton.setProgress(20) }, 500)
+            handler.postDelayed({ circularProgressButton.setProgress(50) }, 1000)
+            handler.postDelayed({ circularProgressButton.setProgress(40) }, 1500)
+            handler.postDelayed({ circularProgressButton.setProgress(100) }, 1900)
+            handler.postDelayed({ circularProgressButton.resetProgress() }, 2300)
+        }
+
         handler.postDelayed(runnable, 3000)
         handler.postDelayed(runnableRevert, 4000)
         handler.postDelayed(runnableRevert, 4100)

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
@@ -49,6 +49,7 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
     private AnimatorSet mAnimatorSet;
 
     private int mFillColorDone;
+    private int progress;
 
     private Bitmap mBitmapDone;
 
@@ -147,6 +148,8 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         if (mGradientDrawable != null) {
             setBackground(mGradientDrawable);
         }
+
+        resetProgress();
     }
 
     @Override
@@ -228,7 +231,7 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         super.onDraw(canvas);
 
         if (mState == State.PROGRESS && !mIsMorphingInProgress) {
-            drawIndeterminateProgress(canvas);
+			drawProgress(canvas);
         } else if(mState == State.DONE){
             drawDoneAnimation(canvas);
         }
@@ -240,7 +243,7 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
      *
      * @param canvas Canvas
      */
-    private void drawIndeterminateProgress(Canvas canvas) {
+	private void drawProgress(Canvas canvas) {
         if (mAnimatedDrawable == null || !mAnimatedDrawable.isRunning()) {
             mAnimatedDrawable = new CircularAnimatedDrawable(this,
                     mParams.mSpinningBarWidth,
@@ -257,10 +260,27 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
             mAnimatedDrawable.setCallback(this);
             mAnimatedDrawable.start();
         } else {
+			mAnimatedDrawable.setProgress(progress);
             mAnimatedDrawable.draw(canvas);
         }
     }
 
+
+    /**
+     * @param progress set a progress to switch displaying a determinate circular progress
+     */
+    public void setProgress(int progress) {
+        progress = Math.max(CircularAnimatedDrawable.MIN_PROGRESS,
+                Math.min(CircularAnimatedDrawable.MAX_PROGRESS, progress));
+        this.progress = progress;
+    }
+
+    /**
+     * resets a given progress and shows an indeterminate progress animation
+     */
+    public void resetProgress() {
+        this.progress = CircularAnimatedDrawable.MIN_PROGRESS - 1;
+    }
 
     /**
      * Stops the animation and sets the button in the STOPED state.
@@ -327,6 +347,7 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         }
 
         mState = State.IDLE;
+        resetProgress();
 
         if(mAnimatedDrawable != null && mAnimatedDrawable.isRunning()){
             stopAnimation();

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressButton.java
@@ -13,9 +13,13 @@ import android.graphics.Canvas;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.InsetDrawable;
 import android.graphics.drawable.StateListDrawable;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.ColorRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.AppCompatButton;
 import android.util.AttributeSet;
@@ -115,8 +119,10 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
 
         mParams.mPaddingProgress = 0f;
 
+        BackgroundAndMorphingDrawables drawables;
+
         if(attrs == null) {
-            loadGradientDrawable(UtilsJava.getDrawable(getContext(), R.drawable.shape_default));
+            drawables = loadGradientDrawable(UtilsJava.getDrawable(getContext(), R.drawable.shape_default));
         } else{
             int[] attrsArray = new int[] {
                     android.R.attr.background, // 0
@@ -125,7 +131,7 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
             TypedArray typedArray =  context.obtainStyledAttributes(attrs, R.styleable.CircularProgressButton, defStyleAttr, defStyleRes);
             TypedArray typedArrayBG = context.obtainStyledAttributes(attrs, attrsArray, defStyleAttr, defStyleRes);
 
-            loadGradientDrawable(typedArrayBG.getDrawable(0));
+            drawables = loadGradientDrawable(typedArrayBG.getDrawable(0));
 
             mParams.mInitialCornerRadius = typedArray.getDimension(
                     R.styleable.CircularProgressButton_initialCornerAngle, 0);
@@ -145,8 +151,12 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
 
         mParams.mText = this.getText().toString();
         mParams.mDrawables = this.getCompoundDrawablesRelative();
-        if (mGradientDrawable != null) {
-            setBackground(mGradientDrawable);
+
+        if (drawables != null) {
+            mGradientDrawable = drawables.morphingDrawable;
+            if (drawables.backGroundDrawable != null) {
+                setBackground(drawables.backGroundDrawable);
+            }
         }
 
         resetProgress();
@@ -162,26 +172,48 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         mGradientDrawable.setColor(ContextCompat.getColor(getContext(), resid));
     }
 
-    private void loadGradientDrawable(Drawable drawable) {
-        try {
-            mGradientDrawable = (GradientDrawable) drawable;
-        } catch (ClassCastException e) {
-            if(drawable instanceof ColorDrawable){
-                ColorDrawable colorDrawable = (ColorDrawable) drawable;
+	/**
+	 * finds or creates the drawable for the morphing animation and the drawable to set the background to
+	 *
+	 * @param drawable Drawable set with android:background setting
+	 * @return BackgroundAndMorphingDrawables object holding the Drawable to morph and to set a background
+	 */
+	@Nullable
+	static BackgroundAndMorphingDrawables loadGradientDrawable(Drawable drawable) {
+        BackgroundAndMorphingDrawables mGradientDrawable = new BackgroundAndMorphingDrawables();
 
-                mGradientDrawable = new GradientDrawable();
-                mGradientDrawable.setColor(colorDrawable.getColor());
-            } else if(drawable instanceof StateListDrawable){
-                StateListDrawable stateListDrawable = (StateListDrawable) drawable;
+		if (drawable == null)
+		    return null;
 
-                try {
-                    mGradientDrawable = (GradientDrawable) stateListDrawable.getCurrent();
-                } catch (ClassCastException e1) {
-                    throw new RuntimeException("Error reading background... Use a shape or a color in xml!", e1.getCause());
-                }
+		else {
+			if (drawable instanceof GradientDrawable) {
+				mGradientDrawable.setBothDrawables((GradientDrawable) drawable);
+			} else if (drawable instanceof ColorDrawable) {
+				ColorDrawable colorDrawable = (ColorDrawable) drawable;
+                GradientDrawable gradientDrawable = new GradientDrawable();
+                gradientDrawable.setColor(colorDrawable.getColor());
+                mGradientDrawable.setBothDrawables(gradientDrawable);
+			} else if (drawable instanceof InsetDrawable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+				InsetDrawable insetDrawable = (InsetDrawable) drawable;
+				mGradientDrawable = loadGradientDrawable(insetDrawable.getDrawable());
+				// use the original inset as background to keep margins, and use the inner drawable for morphing
+				mGradientDrawable.backGroundDrawable = insetDrawable;
+			} else if (drawable instanceof StateListDrawable) {
+				StateListDrawable stateListDrawable = (StateListDrawable) drawable;
+				//try to get the drawable for an active, enabled, unpressed button
+                stateListDrawable.setState(new int[] {android.R.attr.state_enabled, android.R.attr.state_active,
+                        -android.R.attr.state_pressed});
+				Drawable current = stateListDrawable.getCurrent();
+				mGradientDrawable = loadGradientDrawable(current);
+
+			}
+            if (mGradientDrawable.morphingDrawable == null) {
+                throw new RuntimeException("Error reading background... Use a shape or a color in xml!");
             }
         }
-    }
+
+		return mGradientDrawable;
+	}
 
     @Override
     public void setSpinningBarColor(int color) {
@@ -556,5 +588,15 @@ public class CircularProgressButton extends AppCompatButton implements AnimatedB
         private float mInitialCornerRadius;
         private float mFinalCornerRadius;
         private Drawable[] mDrawables;
+    }
+
+    static class BackgroundAndMorphingDrawables {
+        Drawable backGroundDrawable;
+        GradientDrawable morphingDrawable;
+
+        void setBothDrawables(GradientDrawable drawable) {
+            this.backGroundDrawable = drawable;
+            this.morphingDrawable = drawable;
+        }
     }
 }

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
@@ -54,6 +54,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
 
     private Params mParams;
     private boolean doneWhileMorphing;
+    private int progress;
 
     /**
      *
@@ -161,6 +162,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
 
         mState = State.IDLE;
         setBackground(mGradientDrawable);
+        resetProgress();
     }
 
     @Override
@@ -221,7 +223,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
         super.onDraw(canvas);
 
         if (mState == State.PROGRESS && !mIsMorphingInProgress) {
-            drawIndeterminateProgress(canvas);
+            drawProgress(canvas);
         } else if(mState == State.DONE) {
             drawDoneAnimation(canvas);
         }
@@ -233,7 +235,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
      *
      * @param canvas Canvas
      */
-    private void drawIndeterminateProgress(Canvas canvas) {
+    private void drawProgress(Canvas canvas) {
         if (mAnimatedDrawable == null || !mAnimatedDrawable.isRunning()) {
             mAnimatedDrawable = new CircularAnimatedDrawable(this,
                     mParams.mSpinningBarWidth,
@@ -250,8 +252,25 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
             mAnimatedDrawable.setCallback(this);
             mAnimatedDrawable.start();
         } else {
+            mAnimatedDrawable.setProgress(progress);
             mAnimatedDrawable.draw(canvas);
         }
+    }
+
+    /**
+     * @param progress set a progress to switch displaying a determinate circular progress
+     */
+    public void setProgress(int progress) {
+        progress = Math.max(CircularAnimatedDrawable.MIN_PROGRESS,
+                Math.min(CircularAnimatedDrawable.MAX_PROGRESS, progress));
+        this.progress = progress;
+    }
+
+    /**
+     * resets a given progress and shows an indeterminate progress animation
+     */
+    public void resetProgress() {
+        this.progress = CircularAnimatedDrawable.MIN_PROGRESS - 1;
     }
 
     /**
@@ -320,6 +339,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
 
     public void revertAnimation(final OnAnimationEndListener onAnimationEndListener) {
         mState = State.IDLE;
+        resetProgress();
 
         if(mAnimatedDrawable != null && mAnimatedDrawable.isRunning()){
             stopAnimation();

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/customViews/CircularProgressImageButton.java
@@ -114,8 +114,10 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
 
         mParams.mPaddingProgress = 0f;
 
+        CircularProgressButton.BackgroundAndMorphingDrawables drawables;
+
         if(attrs == null) {
-            mGradientDrawable = (GradientDrawable) UtilsJava.getDrawable(getContext(), R.drawable.shape_default);
+            drawables = CircularProgressButton.loadGradientDrawable(UtilsJava.getDrawable(getContext(), R.drawable.shape_default));
         } else{
             int[] attrsArray = new int[] {
                     android.R.attr.background, // 0
@@ -124,27 +126,7 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
             TypedArray typedArray =  context.obtainStyledAttributes(attrs, R.styleable.CircularProgressButton, defStyleAttr, defStyleRes);
             TypedArray typedArrayBG = context.obtainStyledAttributes(attrs, attrsArray, defStyleAttr, defStyleRes);
 
-            try {
-                mGradientDrawable = (GradientDrawable) typedArrayBG.getDrawable(0);
-
-            } catch (ClassCastException e) {
-                Drawable drawable = typedArrayBG.getDrawable(0);
-
-                if(drawable instanceof ColorDrawable){
-                    ColorDrawable colorDrawable = (ColorDrawable) drawable;
-
-                    mGradientDrawable = new GradientDrawable();
-                    mGradientDrawable.setColor(colorDrawable.getColor());
-                } else if(drawable instanceof StateListDrawable){
-                    StateListDrawable stateListDrawable = (StateListDrawable) drawable;
-
-                    try {
-                        mGradientDrawable = (GradientDrawable) stateListDrawable.getCurrent();
-                    } catch (ClassCastException e1) {
-                        throw new RuntimeException("Error reading background... Use a shape or a color in xml!", e1.getCause());
-                    }
-                }
-            }
+            drawables = CircularProgressButton.loadGradientDrawable(typedArrayBG.getDrawable(0));
 
             mParams.mInitialCornerRadius = typedArray.getDimension(
                     R.styleable.CircularProgressButton_initialCornerAngle, 0);
@@ -161,7 +143,14 @@ public class CircularProgressImageButton extends AppCompatImageButton implements
         }
 
         mState = State.IDLE;
-        setBackground(mGradientDrawable);
+
+        if (drawables != null) {
+            mGradientDrawable = drawables.morphingDrawable;
+            if (drawables.backGroundDrawable != null) {
+                setBackground(drawables.backGroundDrawable);
+            }
+        }
+
         resetProgress();
     }
 

--- a/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/interfaces/AnimatedButton.java
+++ b/loading-button-android/src/main/java/br/com/simplepass/loading_button_lib/interfaces/AnimatedButton.java
@@ -9,4 +9,6 @@ public interface AnimatedButton {
     void revertAnimation();
     void revertAnimation(final OnAnimationEndListener onAnimationEndListener);
     void dispose();
+    void setProgress(int progress);
+    void resetProgress();
 }


### PR DESCRIPTION
Our buttons use InsetDrawables for having an outer padding, this was not supported by the lib - it needed GradientDrawables. An InsetDrawable is a container that can hold an inner GradientDrawable.

This PR extends the lib to use the InsetDrawable as the background image while animating the inner GradientDrawable. I have unified the code for the two Progress Buttons.

You can test by using the following drawable xml as the button background:
```
<?xml version="1.0" encoding="utf-8"?>
<selector xmlns:android="http://schemas.android.com/apk/res/android">

	<!-- Normal Buttons State -->
	<item>
		<inset android:insetLeft="4dp"
			   android:insetTop="4dp"
			   android:insetRight="4dp"
			   android:insetBottom="4dp">
			<shape android:shape="rectangle">
				<corners android:radius="2dp"/>
				<solid android:color="@color/cpb_red"/>
				<padding
					android:left="8dp"
					android:top="4dp"
					android:right="8dp"
					android:bottom="4dp"/>
			</shape>
		</inset>
	</item>
</selector>
```

This branch is based on my other PR.