### PR TITLE
fixing stop animation bug

### DIFF
--- a/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
+++ b/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
@@ -51,6 +51,9 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
+        buttonTest7.run { setOnClickListener { morphStopRevert() } }
+        buttonTest8.run { setOnClickListener { morphStopRevert(100, 1000) } }
     }
 }
 
@@ -76,6 +79,12 @@ private fun ProgressButton.morphDoneAndRevert(
 
 private fun ProgressButton.morphAndRevert(revertTime: Long = 3000) {
     startAnimation()
+    Handler().postDelayed({ revertAnimation() }, revertTime)
+}
+
+private fun ProgressButton.morphStopRevert(stopTime: Long = 1000, revertTime: Long = 2000) {
+    startAnimation()
+    Handler().postDelayed({ stopAnimation() }, stopTime)
     Handler().postDelayed({ revertAnimation() }, revertTime)
 }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -150,7 +150,6 @@
             app:spinning_bar_padding="5dp"
             app:spinning_bar_width="5dp" />
 
-
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -159,6 +158,52 @@
 
         <br.com.simplepass.loadingbutton.customViews.CircularProgressButton
             android:id="@+id/buttonTest6"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginLeft="18dp"
+            android:layout_marginRight="18dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/button_shape_default"
+            android:text="Send"
+            android:textColor="@android:color/white"
+            android:theme="@style/BluePrimaryButton"
+            app:finalCornerAngle="50dp"
+            app:initialCornerAngle="0dp"
+            app:spinning_bar_color="#FFFFFFFF"
+            app:spinning_bar_padding="5dp"
+            app:spinning_bar_width="5dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="Test 7 - Start Animation, then Stop" />
+
+        <br.com.simplepass.loadingbutton.customViews.CircularProgressButton
+            android:id="@+id/buttonTest7"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginLeft="18dp"
+            android:layout_marginRight="18dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/button_shape_default"
+            android:text="Send"
+            android:textColor="@android:color/white"
+            android:theme="@style/BluePrimaryButton"
+            app:finalCornerAngle="50dp"
+            app:initialCornerAngle="0dp"
+            app:spinning_bar_color="#FFFFFFFF"
+            app:spinning_bar_padding="5dp"
+            app:spinning_bar_width="5dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="Test 8 - Start Animation, then Stop fast" />
+
+        <br.com.simplepass.loadingbutton.customViews.CircularProgressButton
+            android:id="@+id/buttonTest8"
             android:layout_width="match_parent"
             android:layout_height="50dp"
             android:layout_marginLeft="18dp"

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
@@ -95,7 +95,7 @@ internal class ProgressButtonPresenter(private val view: ProgressButton) {
                 view.stopProgressAnimation()
                 view.startMorphRevertAnimation()
             }
-            State.WAITING_DONE, State.DONE -> {
+            State.WAITING_DONE, State.STOPPED, State.DONE -> {
                 view.startMorphRevertAnimation()
             }
             else -> return
@@ -113,6 +113,10 @@ internal class ProgressButtonPresenter(private val view: ProgressButton) {
                 State.DONE
             }
             State.MORPHING -> State.WAITING_DONE
+            State.STOPPED -> {
+                view.startRevealAnimation()
+                State.DONE
+            }
             else -> State.DONE
         }
     }

--- a/loading-button-android/src/test/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenterTest.kt
+++ b/loading-button-android/src/test/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenterTest.kt
@@ -162,7 +162,11 @@ class ProgressButtonPresenterTest {
     fun `revert animation should do nothing if not in correct stage`() {
         ProgressButtonPresenter(view).run {
             State.values().filterNot { state ->
-                state == State.PROGRESS || state == State.MORPHING || state == State.DONE || state == State.WAITING_DONE
+                state == State.PROGRESS ||
+                    state == State.MORPHING ||
+                    state == State.DONE ||
+                    state == State.WAITING_DONE ||
+                    state == State.STOPPED
             }.forEach { state ->
                 this.state = state
                 revertAnimation()


### PR DESCRIPTION
Revert and done animation were not triggering after `stopAnimation()`. This PR fixes it.

There's still a bug for when `stopAnimation()` get's called too fast.