### PR TITLE
ProgressButton is now Lifecycle-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can check how this library was implemented here (Old version): https://mediu
 
 ## Installation 
 
-    implementation 'br.com.simplepass:loading-button-android:2.0.7'
+    implementation 'br.com.simplepass:loading-button-android:2.1.0'
 
 ## How to use
 
@@ -139,15 +139,18 @@ The button enters this state after `stopAnimation()` when the button is not morp
 This library only supports androidx since prior the version 2.0.0. So don't try to use it with the old Support Library. Use androidx instead.
 
 ### Avoid Memory Leaks
-To avoid memory leaks is your code, you must dispose the buttons in the onDestroy method. Example:
+Prior to version 2.1.0, to avoid memory leaks is your code, you must dispose the buttons in the onDestroy method. Example:
 
     override fun onDestroy() {
             super.onDestroy()
 
             progressButton.dispose()
      }
-     
-     
+
+
+In version 2.1.0, `ProgressButton` was updated to be a `LifecycleObserver` and will automatically
+call `dispose()` when an `onDestroy()` event is observed by the lifecycle owner.
+
 ## Contributing
 ###Setup Git Pre-commit hook script (Optional)
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 

--- a/loading-button-android/build.gradle
+++ b/loading-button-android/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'org.jmailen.kotlinter'
 
-//Bintray depends on this global variable to set the library version!
-version = "2.0.2"
+// Bintray depends on this global variable to set the library version!
+version = "2.1.0"
 group = 'br.com.simplepass'
 
 android {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
@@ -9,6 +9,8 @@ import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.OnLifecycleEvent
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularProgressAnimatedDrawable
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularRevealAnimatedDrawable
 import br.com.simplepass.loadingbutton.animatedDrawables.ProgressType
@@ -157,6 +159,7 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
         presenter.doneLoadingAnimation(fillColor, bitmap)
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun dispose() {
         morphAnimator.disposeAnimator()
         morphRevertAnimator.disposeAnimator()

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
@@ -9,6 +9,8 @@ import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.OnLifecycleEvent
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularProgressAnimatedDrawable
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularRevealAnimatedDrawable
 import br.com.simplepass.loadingbutton.animatedDrawables.ProgressType
@@ -147,6 +149,7 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
         presenter.doneLoadingAnimation(fillColor, bitmap)
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun dispose() {
         morphAnimator.disposeAnimator()
         morphRevertAnimator.disposeAnimator()

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -13,6 +13,7 @@ import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleObserver
 import br.com.simplepass.loadingbutton.R
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularProgressAnimatedDrawable
 import br.com.simplepass.loadingbutton.animatedDrawables.CircularRevealAnimatedDrawable
@@ -20,9 +21,10 @@ import br.com.simplepass.loadingbutton.animatedDrawables.ProgressType
 import br.com.simplepass.loadingbutton.presentation.State
 import br.com.simplepass.loadingbutton.updateHeight
 import br.com.simplepass.loadingbutton.updateWidth
+import br.com.simplepass.loadingbutton.utils.addLifecycleObserver
 import br.com.simplepass.loadingbutton.utils.parseGradientDrawable
 
-interface ProgressButton : Drawable.Callback {
+interface ProgressButton : Drawable.Callback, LifecycleObserver {
     var paddingProgress: Float
     var spinningBarWidth: Float
     var spinningBarColor: Int
@@ -93,6 +95,10 @@ internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int 
 
     typedArray?.recycle()
     typedArrayBg?.recycle()
+
+    // all ProgressButton instances implement LifecycleObserver, so we can
+    // auto-register each instance on initialization
+    getContext().addLifecycleObserver(this)
 }
 
 internal fun ProgressButton.config(tArray: TypedArray) {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
@@ -1,11 +1,15 @@
 package br.com.simplepass.loadingbutton.utils
 
+import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.StateListDrawable
 import android.os.Build
+import android.view.ContextThemeWrapper
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 
 internal fun parseGradientDrawable(drawable: Drawable): GradientDrawable =
     when (drawable) {
@@ -30,3 +34,14 @@ internal fun parseGradientDrawable(drawable: Drawable): GradientDrawable =
         }
         else -> throw RuntimeException("Error reading background... Use a shape or a color in xml!")
     }
+
+internal fun Context.addLifecycleObserver(observer: LifecycleObserver) {
+    when {
+        this is LifecycleOwner ->
+            (this as LifecycleOwner).lifecycle.addObserver(observer)
+        this is ContextThemeWrapper ->
+            (this.baseContext as LifecycleOwner).lifecycle.addObserver(observer)
+        this is androidx.appcompat.view.ContextThemeWrapper ->
+            (this.baseContext as LifecycleOwner).lifecycle.addObserver(observer)
+    }
+}


### PR DESCRIPTION
`ProgressButton` instances now implement `LifecycleObserver` and register for lifecycle events on construction. The only event observed is `onDestroy`, which now automatically disposes animations whenever the `LifecycleOwner` is destroyed.

Closes #102 

