### PR TITLE
Background drawable setting re-implemented 

### DIFF
--- a/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
+++ b/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
@@ -7,12 +7,12 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.os.Handler
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import br.com.simplepass.loadingbutton.animatedDrawables.ProgressType
 import br.com.simplepass.loadingbutton.customViews.ProgressButton
 import kotlinx.android.synthetic.main.activity_main.*
+import android.widget.Toast
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
+++ b/app/src/main/java/br/com/simplepass/loadingbuttonsample/MainActivity.kt
@@ -7,12 +7,12 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.os.Handler
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import br.com.simplepass.loadingbutton.animatedDrawables.ProgressType
 import br.com.simplepass.loadingbutton.customViews.ProgressButton
 import kotlinx.android.synthetic.main.activity_main.*
-import android.widget.Toast
 
 class MainActivity : AppCompatActivity() {
 
@@ -62,6 +62,12 @@ class MainActivity : AppCompatActivity() {
                     Toast.makeText(this@MainActivity, getString(R.string.start_done),
                             Toast.LENGTH_SHORT).show()
                 }
+            }
+        }
+
+        buttonTest10.run {
+            setOnClickListener {
+                morphDoneAndRevert(this@MainActivity)
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -242,5 +242,25 @@
             app:spinning_bar_padding="5dp"
             app:spinning_bar_width="5dp" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="Test 10 - Use any background(like RippleDrawable) and styles(like material button) like Ripple" />
+
+        <br.com.simplepass.loadingbutton.customViews.CircularProgressButton
+            android:id="@+id/buttonTest10"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginLeft="18dp"
+            android:layout_marginRight="18dp"
+            android:layout_marginBottom="20dp"
+            android:text="@string/send"
+            android:textColor="@android:color/white"
+            app:spinning_bar_color="#FFFFFFFF"
+            app:spinning_bar_padding="5dp"
+            app:spinning_bar_width="5dp" />
+
     </LinearLayout>
 </ScrollView>

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/animatedDrawables/CircularRevealAnimatedDrawable.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/animatedDrawables/CircularRevealAnimatedDrawable.kt
@@ -1,7 +1,16 @@
 package br.com.simplepass.loadingbutton.animatedDrawables
 
-import android.animation.*
-import android.graphics.*
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.TimeInterpolator
+import android.animation.ValueAnimator
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.view.animation.DecelerateInterpolator

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/animatedDrawables/CircularRevealAnimatedDrawable.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/animatedDrawables/CircularRevealAnimatedDrawable.kt
@@ -1,16 +1,7 @@
 package br.com.simplepass.loadingbutton.animatedDrawables
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
-import android.animation.TimeInterpolator
-import android.animation.ValueAnimator
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.ColorFilter
-import android.graphics.Paint
-import android.graphics.PixelFormat
+import android.animation.*
+import android.graphics.*
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.view.animation.DecelerateInterpolator
@@ -39,11 +30,11 @@ internal class CircularRevealAnimatedDrawable(
     }
 
     private val bitMapXOffset: Float by lazy {
-        ((bounds.right - bounds.left - bitMapWidth()) / 2).toFloat()
+        (centerWidth - bitMapWidth() / 2).toFloat()
     }
 
     private val bitMapYOffset: Float by lazy {
-        ((bounds.bottom - bounds.top - bitMapHeight()) / 2).toFloat()
+        ((centerHeight - bitMapHeight() / 2)).toFloat()
     }
 
     private val conclusionAnimation: AnimatorSet by lazy {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
@@ -85,9 +85,7 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
         createProgressDrawable()
     }
 
-    private val revealAnimatedDrawable: CircularRevealAnimatedDrawable by lazy {
-        createRevealAnimatedDrawable()
-    }
+    private lateinit var revealAnimatedDrawable: CircularRevealAnimatedDrawable
 
     override fun getState(): State = presenter.state
 
@@ -155,6 +153,10 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
 
     override fun doneLoadingAnimation(fillColor: Int, bitmap: Bitmap) {
         presenter.doneLoadingAnimation(fillColor, bitmap)
+    }
+
+    override fun initRevealAnimation() {
+        revealAnimatedDrawable = createRevealAnimatedDrawable()
     }
 
     fun dispose() {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
@@ -4,8 +4,8 @@ import android.animation.AnimatorSet
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
@@ -43,7 +43,11 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
 
     private lateinit var initialState: InitialState
 
-    override val finalWidth: Int by lazy { finalHeight }
+    override val finalWidth: Int by lazy {
+        val padding = Rect()
+        drawableBackground.getPadding(padding)
+        finalHeight - (Math.abs(padding.top - padding.left) * 2)
+    }
     override val finalHeight: Int by lazy { height }
     private val initialHeight: Int by lazy { height }
 
@@ -53,14 +57,14 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
             progressAnimatedDrawable.progressType = value
         }
 
-    override lateinit var drawable: GradientDrawable
+    override lateinit var drawableBackground: Drawable
 
     private val presenter = ProgressButtonPresenter(this)
 
     private val morphAnimator by lazy {
         AnimatorSet().apply {
             playTogether(
-                cornerAnimator(drawable, initialCorner, finalCorner),
+                cornerAnimator(drawableBackground, initialCorner, finalCorner),
                 widthAnimator(this@CircularProgressButton, initialState.initialWidth, finalWidth),
                 heightAnimator(this@CircularProgressButton, initialHeight, finalHeight)
             )
@@ -72,7 +76,7 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
     private val morphRevertAnimator by lazy {
         AnimatorSet().apply {
             playTogether(
-                cornerAnimator(drawable, finalCorner, initialCorner),
+                cornerAnimator(drawableBackground, finalCorner, initialCorner),
                 widthAnimator(this@CircularProgressButton, finalWidth, initialState.initialWidth),
                 heightAnimator(this@CircularProgressButton, finalHeight, initialHeight)
             )

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
@@ -38,9 +38,6 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
     override var finalCorner = 0F
     override var initialCorner = 0F
 
-    override var doneFillColor: Int = ContextCompat.getColor(context, android.R.color.black)
-    override lateinit var doneImage: Bitmap
-
     private lateinit var initialState: InitialState
 
     override val finalWidth: Int by lazy {
@@ -48,6 +45,7 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
         drawableBackground.getPadding(padding)
         finalHeight - (Math.abs(padding.top - padding.left) * 2)
     }
+
     override val finalHeight: Int by lazy { height }
     private val initialHeight: Int by lazy { height }
 
@@ -159,8 +157,8 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
         presenter.doneLoadingAnimation(fillColor, bitmap)
     }
 
-    override fun initRevealAnimation() {
-        revealAnimatedDrawable = createRevealAnimatedDrawable()
+    override fun initRevealAnimation(fillColor: Int, bitmap: Bitmap) {
+        revealAnimatedDrawable = createRevealAnimatedDrawable(fillColor, bitmap)
     }
 
     fun dispose() {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
@@ -4,8 +4,8 @@ import android.animation.AnimatorSet
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
@@ -45,7 +45,11 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
 
     override val finalHeight: Int by lazy { height }
     private val initialHeight: Int by lazy { height }
-    override val finalWidth: Int by lazy { finalHeight }
+    override val finalWidth: Int by lazy {
+        val padding = Rect()
+        drawableBackground.getPadding(padding)
+        finalHeight - (Math.abs(padding.top - padding.left) * 2)
+    }
 
     override var progressType: ProgressType
         get() = progressAnimatedDrawable.progressType
@@ -53,14 +57,14 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
             progressAnimatedDrawable.progressType = value
         }
 
-    override lateinit var drawable: GradientDrawable
+    override lateinit var drawableBackground: Drawable
 
     private val presenter = ProgressButtonPresenter(this)
 
     private val morphAnimator by lazy {
         AnimatorSet().apply {
             playTogether(
-                cornerAnimator(drawable, initialCorner, finalCorner),
+                cornerAnimator(drawableBackground, initialCorner, finalCorner),
                 widthAnimator(this@CircularProgressImageButton, initialState.initialWidth, finalWidth),
                 heightAnimator(this@CircularProgressImageButton, initialHeight, finalHeight)
             )
@@ -72,7 +76,7 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
     private val morphRevertAnimator by lazy {
         AnimatorSet().apply {
             playTogether(
-                cornerAnimator(drawable, finalCorner, initialCorner),
+                cornerAnimator(drawableBackground, finalCorner, initialCorner),
                 widthAnimator(this@CircularProgressImageButton, finalWidth, initialState.initialWidth),
                 heightAnimator(this@CircularProgressImageButton, finalHeight, initialHeight)
             )

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
@@ -38,9 +38,6 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
     override var finalCorner = 0F
     override var initialCorner = 0F
 
-    override var doneFillColor: Int = ContextCompat.getColor(context, android.R.color.black)
-    override lateinit var doneImage: Bitmap
-
     private lateinit var initialState: InitialState
 
     override val finalHeight: Int by lazy { height }
@@ -149,8 +146,8 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
         presenter.doneLoadingAnimation(fillColor, bitmap)
     }
 
-    override fun initRevealAnimation() {
-        revealAnimatedDrawable = createRevealAnimatedDrawable()
+    override fun initRevealAnimation(fillColor: Int, bitmap: Bitmap) {
+        revealAnimatedDrawable = createRevealAnimatedDrawable(fillColor, bitmap)
     }
 
     fun dispose() {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
@@ -85,9 +85,7 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
         createProgressDrawable()
     }
 
-    private val revealAnimatedDrawable: CircularRevealAnimatedDrawable by lazy {
-        createRevealAnimatedDrawable()
-    }
+    private lateinit var revealAnimatedDrawable: CircularRevealAnimatedDrawable
 
     override fun getState(): State = presenter.state
 
@@ -145,6 +143,10 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
 
     override fun doneLoadingAnimation(fillColor: Int, bitmap: Bitmap) {
         presenter.doneLoadingAnimation(fillColor, bitmap)
+    }
+
+    override fun initRevealAnimation() {
+        revealAnimatedDrawable = createRevealAnimatedDrawable()
     }
 
     fun dispose() {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -70,6 +70,7 @@ interface ProgressButton : Drawable.Callback {
     fun drawDoneAnimation(canvas: Canvas)
 
     fun setProgress(value: Float)
+    fun initRevealAnimation()
 }
 
 internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int = 0) {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -35,9 +35,6 @@ interface ProgressButton : Drawable.Callback {
     val finalWidth: Int
     val finalHeight: Int
 
-    var doneFillColor: Int
-    var doneImage: Bitmap
-
     var drawableBackground: Drawable
     var progressType: ProgressType
 
@@ -72,7 +69,7 @@ interface ProgressButton : Drawable.Callback {
     fun drawDoneAnimation(canvas: Canvas)
 
     fun setProgress(value: Float)
-    fun initRevealAnimation()
+    fun initRevealAnimation(fillColor: Int, bitmap: Bitmap)
 }
 
 internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int = 0) {
@@ -85,18 +82,15 @@ internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int 
         getContext().obtainStyledAttributes(this, attrsArray, defStyleAttr, 0)
     }
 
-    val tempDrawable = typedArrayBg?.getDrawable(0)
-            ?: ContextCompat.getDrawable(getContext(), R.drawable.shape_default)!!
-    drawableBackground = tempDrawable.let {
+    drawableBackground = typedArrayBg?.getDrawable(0)
+        ?: ContextCompat.getDrawable(getContext(), R.drawable.shape_default)!!.let {
         when (it) {
             is ColorDrawable -> GradientDrawable().apply { setColor(it.color) }
             else -> it
         }
-    }
-    if (typedArray?.getBoolean(R.styleable.CircularProgressButton_use_drawable_cache, false) == false) {
-        drawableBackground = drawableBackground.constantState?.newDrawable()?.mutate()
-                ?: drawableBackground
-    }
+        }.let {
+            drawableBackground.constantState?.newDrawable()?.mutate() ?: it
+        }
 
     setBackground(drawableBackground)
 
@@ -132,8 +126,8 @@ internal fun ProgressButton.createProgressDrawable(): CircularProgressAnimatedDr
         callback = this@createProgressDrawable
     }
 
-internal fun ProgressButton.createRevealAnimatedDrawable(): CircularRevealAnimatedDrawable =
-    CircularRevealAnimatedDrawable(this, doneFillColor, doneImage).apply {
+internal fun ProgressButton.createRevealAnimatedDrawable(fillColor: Int, bitmap: Bitmap): CircularRevealAnimatedDrawable =
+    CircularRevealAnimatedDrawable(this, fillColor, bitmap).apply {
         val padding = Rect()
         drawableBackground.getPadding(padding)
         val paddingSides = (Math.abs(padding.top - padding.left))

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
@@ -36,7 +37,7 @@ interface ProgressButton : Drawable.Callback {
     var doneFillColor: Int
     var doneImage: Bitmap
 
-    var drawable: GradientDrawable
+    var drawableBackground: Drawable
     var progressType: ProgressType
 
     fun invalidate()
@@ -83,12 +84,10 @@ internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int 
         getContext().obtainStyledAttributes(this, attrsArray, defStyleAttr, 0)
     }
 
-    drawable = parseGradientDrawable(
-        typedArrayBg?.getDrawable(0)
+    drawableBackground = typedArrayBg?.getDrawable(0)
             ?: ContextCompat.getDrawable(getContext(), R.drawable.shape_default)!!
-    )
 
-    setBackground(drawable)
+    setBackground(drawableBackground)
 
     typedArray?.let { tArray -> config(tArray) }
 
@@ -110,10 +109,13 @@ internal fun ProgressButton.createProgressDrawable(): CircularProgressAnimatedDr
     CircularProgressAnimatedDrawable(this, spinningBarWidth, spinningBarColor).apply {
         val offset = (finalWidth - finalHeight) / 2
 
-        val left = offset + paddingProgress.toInt()
-        val right = finalWidth - offset - paddingProgress.toInt()
-        val bottom = finalHeight - paddingProgress.toInt()
-        val top = paddingProgress.toInt()
+        val padding = Rect()
+        drawableBackground.getPadding(padding)
+
+        val left = offset + paddingProgress.toInt() + padding.bottom
+        val right = finalWidth - offset - paddingProgress.toInt() - padding.bottom
+        val bottom = finalHeight - paddingProgress.toInt() - padding.bottom
+        val top = paddingProgress.toInt() + padding.top
 
         setBounds(left, top, right, bottom)
         callback = this@createProgressDrawable
@@ -121,12 +123,18 @@ internal fun ProgressButton.createProgressDrawable(): CircularProgressAnimatedDr
 
 internal fun ProgressButton.createRevealAnimatedDrawable(): CircularRevealAnimatedDrawable =
     CircularRevealAnimatedDrawable(this, doneFillColor, doneImage).apply {
-        setBounds(0, 0, finalWidth, finalHeight)
+        val padding = Rect()
+        drawableBackground.getPadding(padding)
+        val paddingSides = (Math.abs(padding.top - padding.left))
+        setBounds(paddingSides, padding.top, finalWidth - paddingSides, finalHeight - padding.bottom)
         callback = this@createRevealAnimatedDrawable
     }
 
-internal fun cornerAnimator(drawable: GradientDrawable, initial: Float, final: Float) =
-    ObjectAnimator.ofFloat(drawable, "cornerRadius", initial, final)
+internal fun cornerAnimator(drawable: Drawable, initial: Float, final: Float) =
+    when (drawable) {
+        is GradientDrawable -> ObjectAnimator.ofFloat(drawable, "cornerRadius", initial, final)
+        else -> ObjectAnimator.ofFloat(parseGradientDrawable(drawable), "cornerRadius", initial, final)
+    }
 
 internal fun widthAnimator(view: View, initial: Int, final: Int) =
     ValueAnimator.ofInt(initial, final).apply {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -84,15 +84,16 @@ internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int 
         getContext().obtainStyledAttributes(this, attrsArray, defStyleAttr, 0)
     }
 
-    drawableBackground = typedArrayBg?.getDrawable(0)
+    val tempDrawable = typedArrayBg?.getDrawable(0)
         ?: ContextCompat.getDrawable(getContext(), R.drawable.shape_default)!!.let {
         when (it) {
             is ColorDrawable -> GradientDrawable().apply { setColor(it.color) }
             else -> it
         }
-        }.let {
-            drawableBackground.constantState?.newDrawable()?.mutate() ?: it
         }
+    drawableBackground = tempDrawable.let {
+        it.constantState?.newDrawable()?.mutate() ?: it
+    }
 
     setBackground(drawableBackground)
 

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/ProgressButton.kt
@@ -9,6 +9,7 @@ import android.content.res.TypedArray
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
@@ -84,8 +85,18 @@ internal fun ProgressButton.init(attrs: AttributeSet? = null, defStyleAttr: Int 
         getContext().obtainStyledAttributes(this, attrsArray, defStyleAttr, 0)
     }
 
-    drawableBackground = typedArrayBg?.getDrawable(0)
+    val tempDrawable = typedArrayBg?.getDrawable(0)
             ?: ContextCompat.getDrawable(getContext(), R.drawable.shape_default)!!
+    drawableBackground = tempDrawable.let {
+        when (it) {
+            is ColorDrawable -> GradientDrawable().apply { setColor(it.color) }
+            else -> it
+        }
+    }
+    if (typedArray?.getBoolean(R.styleable.CircularProgressButton_use_drawable_cache, false) == false) {
+        drawableBackground = drawableBackground.constantState?.newDrawable()?.mutate()
+                ?: drawableBackground
+    }
 
     setBackground(drawableBackground)
 

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
@@ -111,6 +111,7 @@ internal class ProgressButtonPresenter(private val view: ProgressButton) {
     fun doneLoadingAnimation(fillColor: Int, bitmap: Bitmap) {
         view.doneFillColor = fillColor
         view.doneImage = bitmap
+        view.initRevealAnimation()
 
         state = when (state) {
             State.PROGRESS -> {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenter.kt
@@ -109,9 +109,7 @@ internal class ProgressButtonPresenter(private val view: ProgressButton) {
     }
 
     fun doneLoadingAnimation(fillColor: Int, bitmap: Bitmap) {
-        view.doneFillColor = fillColor
-        view.doneImage = bitmap
-        view.initRevealAnimation()
+        view.initRevealAnimation(fillColor, bitmap)
 
         state = when (state) {
             State.PROGRESS -> {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
@@ -1,10 +1,6 @@
 package br.com.simplepass.loadingbutton.utils
 
-import android.graphics.drawable.ColorDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
-import android.graphics.drawable.InsetDrawable
-import android.graphics.drawable.StateListDrawable
+import android.graphics.drawable.*
 import android.os.Build
 
 internal fun parseGradientDrawable(drawable: Drawable): GradientDrawable =
@@ -14,7 +10,16 @@ internal fun parseGradientDrawable(drawable: Drawable): GradientDrawable =
         is InsetDrawable -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 drawable.drawable?.let { innerDrawable ->
-                    parseGradientDrawable(innerDrawable)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        when (innerDrawable) {
+                            is RippleDrawable -> {
+                                parseGradientDrawable(innerDrawable.getDrawable(0))
+                            }
+                            else -> parseGradientDrawable(innerDrawable)
+                        }
+                    } else {
+                        parseGradientDrawable(innerDrawable)
+                    }
                 }
                     ?: throw RuntimeException("Error reading background... Use a shape or a color in xml!")
             } else {

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/utils/Utils.kt
@@ -1,6 +1,11 @@
 package br.com.simplepass.loadingbutton.utils
 
-import android.graphics.drawable.*
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
 import android.os.Build
 
 internal fun parseGradientDrawable(drawable: Drawable): GradientDrawable =

--- a/loading-button-android/src/main/res/values/attrs.xml
+++ b/loading-button-android/src/main/res/values/attrs.xml
@@ -6,5 +6,6 @@
         <attr name="spinning_bar_padding" format="dimension"/>
         <attr name="initialCornerAngle" format="dimension"/>
         <attr name="finalCornerAngle" format="dimension"/>
+        <attr name="use_drawable_cache" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/loading-button-android/src/main/res/values/attrs.xml
+++ b/loading-button-android/src/main/res/values/attrs.xml
@@ -6,6 +6,5 @@
         <attr name="spinning_bar_padding" format="dimension"/>
         <attr name="initialCornerAngle" format="dimension"/>
         <attr name="finalCornerAngle" format="dimension"/>
-        <attr name="use_drawable_cache" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/loading-button-android/src/test/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenterTest.kt
+++ b/loading-button-android/src/test/java/br/com/simplepass/loadingbutton/presentation/ProgressButtonPresenterTest.kt
@@ -6,7 +6,6 @@ import br.com.simplepass.loadingbutton.customViews.ProgressButton
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import org.junit.Assert.assertEquals
@@ -263,11 +262,6 @@ class ProgressButtonPresenterTest {
                     this.state = state
                     doneLoadingAnimation(0, bitmapMock)
                 }
-        }
-
-        verify(view, times(9)).run {
-            doneFillColor = 0
-            doneImage = bitmapMock
         }
 
         verify(view, never()).run {


### PR DESCRIPTION
I've changed approach to background drawable fetching and settings. This allows usage of all(at least I think it should cover all drawables). Background is now optional if for example style with background is used. I've also added test case to show how it works and rest of test seems to be working fine.

Additionally this should fix issues #120, #42, #34. Also there was a bug where background in other buttons where changed during or after animation background because framework is caching background drawable.