### PR TITLE
Nullable AttributeSet

### DIFF
--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressButton.kt
@@ -24,11 +24,11 @@ open class CircularProgressButton : AppCompatButton, ProgressButton {
         init()
     }
 
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(attrs)
     }
 
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
         init(attrs, defStyleAttr)
     }
 

--- a/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
+++ b/loading-button-android/src/main/java/br/com/simplepass/loadingbutton/customViews/CircularProgressImageButton.kt
@@ -24,11 +24,11 @@ open class CircularProgressImageButton : AppCompatImageButton, ProgressButton {
         init()
     }
 
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(attrs)
     }
 
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
         init(attrs, defStyleAttr)
     }
 


### PR DESCRIPTION
AttributeSet should be made nullable, as all views have nullable AttributeSet for programmatic use.

`AppCompatButton` and `AppCompatImageButton` allow for nullable `AttributeSet` and `ProgressButton.init` allows for nullable `AttributeSet` as well.

The only change that is to the constructors for `CircularProgressButton` and `CircularProgressImageButton`