### PR TITLE
replace bintray with jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[ ![Download](https://api.bintray.com/packages/lehen01/maven/loading-button/images/download.svg) ](https://bintray.com/lehen01/maven/loading-button/_latestVersion)[![Build Status](https://travis-ci.org/leandroBorgesFerreira/LoadingButtonAndroid.svg?branch=master)](https://travis-ci.org/leandroBorgesFerreira/LoadingButtonAndroid)
+[![](https://jitpack.io/v/codegamez/LoadingButtonAndroid.svg)](https://jitpack.io/#codegamez/LoadingButtonAndroid)
 
 Hey, if you think this (or other of my projects) help you some how, please consider giving me some sponsorship: https://github.com/sponsors/leandroBorgesFerreira
 (Open source software can be quite a work haha)
@@ -31,7 +31,19 @@ You can check how this library was implemented here (Old version): https://mediu
 
 ## Installation 
 
-    implementation 'br.com.simplepass:loading-button-android:2.2.0'
+```gradle
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+}
+```
+
+```gradle
+dependencies {
+    implementation 'com.github.codegamez:LoadingButtonAndroid:2.2.1'
+}
+```
 
 ## How to use
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
         mavenCentral()
         maven {
             url = uri("https://plugins.gradle.org/m2/")
@@ -13,7 +12,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.ajoberstar:grgit:1.5.0'
@@ -28,7 +26,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 
     subprojects {

--- a/loading-button-android/build.gradle
+++ b/loading-button-android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'org.jmailen.kotlinter'
 
 // Bintray depends on this global variable to set the library version!
-version = "2.2.0"
+version = "2.2.1"
 group = 'br.com.simplepass'
 
 android {
@@ -65,65 +65,6 @@ artifacts {
     archives sourcesJar
 }
 
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name 'LoadingButtonAndroid'
-            description 'A button to substitute the ProgressDialog'
-            url 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid'
-            inceptionYear '2017'
-
-            packaging 'aar'
-            groupId 'br.com.simplepass'
-            artifactId 'loading-button-android'
-            version version
-
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                connection 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid.git'
-                url 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid'
-
-            }
-            developers {
-                developer {
-                    name 'Leandro Borges Ferreira'
-                }
-            }
-        }
-    }
-}
-
-// Configure gradle-bintray-plugin (for publishing releases)
-bintray {
-    configurations = ['archives']
-
-    publish = true
-
-    pkg {
-        repo = 'maven'
-        name = 'loading-button'
-        userOrg = 'lehen01'
-        licenses = ['Apache-2.0']
-        labels = ['customview', 'fragment', 'map']
-        websiteUrl = 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid'
-        issueTrackerUrl = 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid/issues'
-        vcsUrl = 'https://github.com/leandroBorgesFerreira/LoadingButtonAndroid.git'
-        publicDownloadNumbers = true
-    }
-
-}
-
-if (project.hasProperty('bintrayUser') && project.hasProperty('bintrayKey')) {
-    bintray.user = project.bintrayUser
-    bintray.key = project.bintrayKey
-}
-
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
@@ -135,6 +76,17 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
 }
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+            }
+        }
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
bintray is shut down and not working anymore. so the library is not usable right now. I replaced bintray with jitpack.